### PR TITLE
feat(SassGrid): Updated deprecated function usages and imports

### DIFF
--- a/src/sass/README.md
+++ b/src/sass/README.md
@@ -1,5 +1,9 @@
 # SASS Grid
 
+## Implementation
+
+As `@import` is deprecated use `@forward "~@nfq/react-grid/sass";` to implement sass grid from now on don't use `@use '...' as ...`.
+
 ## Usage
 This gird is based on scss and uses the following variables to generate the grid.
 ```

--- a/src/sass/_css-variables.scss
+++ b/src/sass/_css-variables.scss
@@ -1,7 +1,7 @@
-@import 'config';
+@use 'config';
 
 @function numberedValue($value){
-    @if type-of($value) == 'string' {
+    @if meta.type-of($value) == 'string' {
         @return $value;
     } @else {
         @return #{$value}px;
@@ -37,11 +37,11 @@
 }
 
 @function breakpoint($name){
-    @if not map-get($breakpoints, $name){
+    @if not map.get($breakpoints, $name){
         @error "Breakpoint `#{$name}` not found.";
     }
 
-    @return var(--breakpoint-#{unquote($name)});
+    @return var(--breakpoint-#{string.unquote($name)});
 }
 
 @function columns(){
@@ -49,27 +49,27 @@
 }
 
 @function container($name){
-    @if not map-get($container, $name){
+    @if not map.get($container, $name){
         @error "Container `#{$name}` not found.";
     }
 
-    @return var(--container-#{unquote($name)});
+    @return var(--container-#{string.unquote($name)});
 }
 
 @function gapWidth($name){
-    @if not map-get($gapWidth, $name){
+    @if not map.get($gapWidth, $name){
         @error "GapWidth `#{$name}` not found.";
     }
 
-    @return var(--gap-width-#{unquote($name)});
+    @return var(--gap-width-#{string.unquote($name)});
 }
 
 @function containerPadding($name){
-    @if not map-get($containerPaddingWidth, $name){
+    @if not map.get($containerPaddingWidth, $name){
         @error "Container Padding `#{$name}` not found.";
     }
 
-    @return var(--container-padding-#{unquote($name)});
+    @return var(--container-padding-#{string.unquote($name)});
 }
 
 @function baseSpacing(){

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -1,13 +1,13 @@
-@import 'variables';
-@import 'css-variables';
-@import 'css-functions';
+@use 'variables';
+@use 'css-variables';
+@use 'css-functions';
 
-@import 'grid/container';
-@import 'grid/row';
-@import 'grid/col';
-@import 'grid/spacer';
+@use 'grid/container';
+@use 'grid/row';
+@use 'grid/col';
+@use 'grid/spacer';
 
-@import 'grid/utils';
+@use 'grid/utils';
 
 @each $dimension in $dimensions {
     @include exludeXSMediaUp($dimension) {

--- a/src/sass/functions.scss
+++ b/src/sass/functions.scss
@@ -1,3 +1,3 @@
-@import 'variables';
-@import 'css-variables';
-@import 'css-functions';
+@use 'variables';
+@use 'css-variables';
+@use 'css-functions';

--- a/src/sass/grid/_col.scss
+++ b/src/sass/grid/_col.scss
@@ -12,17 +12,17 @@ $colSizes: (
     $dimensionString: '-';
 
     @if $dimension != 'xs' {
-        $dimensionString: -#{unquote($dimension)}-;
+        $dimensionString: -#{string.unquote($dimension)}-;
     };
 
     @each $sizeName, $value in $colSizes {
         .col#{$dimensionString}#{$sizeName} {
-            flex: 0 0 unquote($value);
+            flex: 0 0 string.unquote($value);
 
             @if $sizeName == 'auto' {
                 max-width: 100%;
             } @else {
-                max-width: unquote($value);
+                max-width: string.unquote($value);
             }
         }
     }
@@ -41,19 +41,19 @@ $colSizes: (
     }
 
     @each $align, $value in $align-items {
-        .col-align#{$dimensionString}#{unquote($align)} {
+        .col-align#{$dimensionString}#{string.unquote($align)} {
             align-items: $value;
         }
-        .col-align-self#{$dimensionString}#{unquote($align)} {
+        .col-align-self#{$dimensionString}#{string.unquote($align)} {
             align-self: $value;
         }
     }
 
     @each $justify, $value in $justify-content {
-        .col-justify#{$dimensionString}#{unquote($justify)} {
+        .col-justify#{$dimensionString}#{string.unquote($justify)} {
             justify-content: $value;
         }
-        .col-justify-self#{$dimensionString}#{unquote($justify)} {
+        .col-justify-self#{$dimensionString}#{string.unquote($justify)} {
             justify-self: $value;
         }
     }

--- a/src/sass/grid/_row.scss
+++ b/src/sass/grid/_row.scss
@@ -9,11 +9,11 @@
     $dimensionString: '-';
 
     @if $dimension != 'xs' {
-        $dimensionString: -#{unquote($dimension)}-;
+        $dimensionString: -#{string.unquote($dimension)}-;
     };
 
     :root {
-        --current-row-gap: #{gapWidth(#{$dimension})};
+        --current-row-gap: #{string.gapWidth(#{$dimension})};
     }
 
     .row {
@@ -25,13 +25,13 @@
     }
 
     @each $align, $value in $align-items {
-        .row-align#{$dimensionString}#{unquote($align)} {
+        .row-align#{$dimensionString}#{string.unquote($align)} {
             align-items: $value;
         }
     }
 
     @each $justify, $value in $justify-content {
-        .row-justify#{$dimensionString}#{unquote($justify)} {
+        .row-justify#{$dimensionString}#{string.unquote($justify)} {
             justify-content: $value;
         }
     }

--- a/src/sass/grid/_spacer.scss
+++ b/src/sass/grid/_spacer.scss
@@ -7,7 +7,7 @@
     $dimensionString: '-';
 
     @if $dimension != 'xs' {
-        $dimensionString: -#{unquote($dimension)}-;
+        $dimensionString: -#{string.unquote($dimension)}-;
     };
 
     .spacer#{$dimensionString}inline {

--- a/src/sass/grid/_utils.scss
+++ b/src/sass/grid/_utils.scss
@@ -4,7 +4,7 @@
     $dimensionString: '-';
 
     @if $dimension != 'xs' {
-        $dimensionString: -#{unquote($dimension)}-;
+        $dimensionString: -#{string.unquote($dimension)}-;
     };
 
     .order#{$dimensionString}first {
@@ -25,7 +25,7 @@
     $dimensionString: '-';
 
     @if $dimension != 'xs' {
-        $dimensionString: -#{unquote($dimension)}-;
+        $dimensionString: -#{string.unquote($dimension)}-;
     };
 
     @each $utilityKey, $utility in $utilities {
@@ -34,7 +34,7 @@
 
         @each $key, $value in map.get($utility, 'values') {
             .#{$classString}#{$key} {
-                #{map.get($utility, 'property')}: unquote($value);
+                #{map.get($utility, 'property')}: string.unquote($value);
             }
         }
     }


### PR DESCRIPTION
BREAKING CHANGES: Moved from @imports to @use - from now on use @forward to implement scss-grid e.g. "@forward "~@nfq/react-grid/sass";"
